### PR TITLE
Say why the Pakled stayed quiet, and show it thinking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,11 @@ OPENROUTER_API_KEY=
 # Defaults to ./data locally; the container mounts /data.
 PAKLED_DATA_DIR=./data
 
+# Overrides logging.level from config.yaml: debug | info | warn | error.
+# Raising the level to watch a live problem is then a restart, not an edit to the
+# config file the container mounts. Unset, config.yaml decides.
+PAKLED_LOG_LEVEL=
+
 # ── Invite URL ───────────────────────────────────────────────────────────────
 # Replace <APPLICATION_ID> with your app's id. Grants exactly the four
 # permissions the bot needs: View Channels, Send Messages, Read Message History,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## v0.2.0 — Grunk Is Thinking
+
+The bot was already silent in five different ways and could not tell you which one
+it was doing. This release is about being able to answer "why did it not reply?"
+without guessing.
+
+### Saying why it stayed quiet
+
+A mention can be declined for four separate reasons — the channel is denied, the
+question was empty once the mention was stripped, the user is inside the mention
+cooldown, or the channel is. All four returned `null` and logged nothing, which
+made an ignored mention indistinguishable from a dead process. Each now reports
+its reason at debug level, and a mention that arrives at all is logged the moment
+it is recognised: if a mention is never logged, it never reached the bot.
+
+### Watching the gateway
+
+There was no connection logging whatsoever. A shard disconnect is now a warning
+with its close code, and a resume is logged with `replayedEvents` — the number
+that says whether messages were replayed or quietly lost. Messages sent during a
+gateway gap are never delivered, so this is usually the real answer when the bot
+appears to ignore someone.
+
+### A swallowed send is no longer silent
+
+`sendTo` caught every failure and returned `false` with no explanation, so the bot
+could decide to speak, fail to speak, and log nothing about it. It now reports the
+reason, wired up for both unprompted speech and Ceremony beats.
+
+The passive cycle's remaining silent exits — no speakable channel, no provider, a
+channel that vanished, an unreadable history — say so too.
+
+### Grunk is typing
+
+The Pakled shows a typing indicator while a model is composing its reply, refreshed
+under Discord's ten-second expiry so a slow model does not appear to have wandered
+off. It starts only once every gate has passed, so the bot never appears to be
+typing an answer it has already decided not to give.
+
+### PAKLED_LOG_LEVEL
+
+Overrides `logging.level` from the environment. Turning on debug to watch a live
+problem is now a restart of the container rather than an edit to the config file it
+mounts. An unrecognised value fails at startup rather than quietly logging at the
+wrong level.
+
 ## v0.1.0 — The Great Helmet Barrel
 
 First release. The bot runs unattended, redistributes helmets on its own schedule,

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Identity and secrets come from the environment instead — see
 | `DISCORD_GUILD_ID` | required |
 | `OPENROUTER_API_KEY` | optional; without it the Pakled speaks in fallback lines |
 | `PAKLED_DATA_DIR` | where `config.yaml` and `bot.sqlite` live (`/data` in the container) |
+| `PAKLED_LOG_LEVEL` | optional; overrides `logging.level`, so raising it is a restart rather than a config edit |
 
 ### With Docker
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -8,6 +8,8 @@ enabled: true
 
 logging:
   level: info # debug | info | warn | error
+  # PAKLED_LOG_LEVEL overrides this, so raising the level to watch a live problem
+  # is a restart rather than an edit to the file the container mounts.
 
 development:
   dryRun: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-pakled-helmetbot",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { parse } from "yaml";
 import { z } from "zod";
-import { LEVELS } from "./logger.ts";
+import { LEVELS, type Level } from "./logger.ts";
 
 /**
  * Configuration is read-only input describing behaviour. Identity and secrets come
@@ -164,6 +164,11 @@ export type Environment = {
    */
   openrouterApiKey: string | null;
   dataDir: string;
+  /**
+   * Overrides logging.level when set. Turning on debug to watch a live problem is a
+   * restart of the container, not an edit to the config file it mounts.
+   */
+  logLevel: Level | null;
 };
 
 export class ConfigError extends Error {}
@@ -174,11 +179,23 @@ const required = (env: NodeJS.ProcessEnv, key: string): string => {
   return value;
 };
 
+/** Unset is fine; a typo is not — silently logging at the wrong level is the bug
+ *  this override exists to avoid. */
+const logLevel = (env: NodeJS.ProcessEnv): Level | null => {
+  const value = env.PAKLED_LOG_LEVEL?.trim().toLowerCase();
+  if (!value) return null;
+  if (!(LEVELS as readonly string[]).includes(value)) {
+    throw new ConfigError(`PAKLED_LOG_LEVEL is "${value}". Expected one of: ${LEVELS.join(", ")}.`);
+  }
+  return value as Level;
+};
+
 export const loadEnvironment = (env: NodeJS.ProcessEnv = process.env): Environment => ({
   discordToken: required(env, "DISCORD_TOKEN"),
   discordGuildId: required(env, "DISCORD_GUILD_ID"),
   openrouterApiKey: env.OPENROUTER_API_KEY?.trim() || null,
   dataDir: env.PAKLED_DATA_DIR?.trim() || "./data",
+  logLevel: logLevel(env),
 });
 
 export const parseConfig = (source: string): Config => {

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -232,13 +232,26 @@ export const speakableChannels = (guild: Guild, botId: string): { id: string; pa
     })
     .map((c) => ({ id: c.id, parentId: c.parentId }));
 
-export const sendTo = async (guild: Guild, channelId: string, text: string): Promise<boolean> => {
+/**
+ * `onError` exists because a swallowed send is the worst failure this bot has: it
+ * decided to speak, nothing appeared, and every log says it worked.
+ */
+export const sendTo = async (
+  guild: Guild,
+  channelId: string,
+  text: string,
+  onError?: (reason: string) => void,
+): Promise<boolean> => {
   try {
     const channel = await guild.channels.fetch(channelId);
-    if (channel === null || !channel.isTextBased()) return false;
+    if (channel === null || !channel.isTextBased()) {
+      onError?.("the channel is missing or is not text-based");
+      return false;
+    }
     await channel.send({ content: text, allowedMentions: { parse: [] } });
     return true;
-  } catch {
+  } catch (cause) {
+    onError?.((cause as Error).message);
     return false;
   }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,6 +112,21 @@ const runDaemon = async (args: {
   let passiveInFlight: Promise<void> | null = null;
   let stopping = false;
 
+  // A gateway gap is invisible from inside the handlers: messages sent during one
+  // are never delivered and never replayed beyond what a resume carries. Without
+  // these, "the bot ignored me" and "the bot never saw it" look identical.
+  client.on(Events.ShardDisconnect, (event, shardId) =>
+    log.warn("gateway disconnected", { shardId, code: event.code, reason: event.reason || null }),
+  );
+  client.on(Events.ShardReconnecting, (shardId) => log.debug("gateway reconnecting", { shardId }));
+  // replayedEvents is the number that matters: zero after a long gap means messages
+  // were dropped, not merely delayed.
+  client.on(Events.ShardResume, (shardId, replayedEvents) => log.info("gateway resumed", { shardId, replayedEvents }));
+  client.on(Events.ShardError, (error, shardId) => log.error("gateway error", { shardId, reason: error.message }));
+  client.on(Events.GuildUnavailable, (unavailable) => {
+    if (unavailable.id === guildId) log.warn("the guild went unavailable; Discord is having trouble");
+  });
+
   const describe = (schedule: Schedule) => ({
     nextCeremonyAt: schedule.nextCeremonyAt === null ? null : new Date(schedule.nextCeremonyAt).toISOString(),
     paused: schedule.paused,
@@ -198,7 +213,11 @@ const runDaemon = async (args: {
       // Nothing may escape: the emitter cannot observe this promise.
       void (async () => {
         if (message.author.bot || message.guildId !== guildId) return;
+        // The first question of any silence is whether the mention arrived at all: a
+        // reply with its ping switched off, or a role mention, reads as a mention to a
+        // human but never reaches mentions.users.
         if (!message.mentions.users.has(client.user.id)) return;
+        log.debug("mentioned", { userId: message.author.id, channelId: message.channelId });
         if (answering >= config.conversation.maxConcurrentMentions) {
           log.warn("ignoring a mention: already answering as many as allowed at once");
           return;
@@ -210,10 +229,29 @@ const runDaemon = async (args: {
         } finally {
           answering--;
         }
-      })().catch((cause: unknown) => log.error("mention failed", { reason: (cause as Error).message }));
+      })().catch((cause: unknown) =>
+        log.error("mention failed", {
+          reason: (cause as Error).message,
+          userId: message.author.id,
+          channelId: message.channelId,
+        }),
+      );
     });
 
     const respondToMention = async (message: Message): Promise<void> => {
+      // Discord's indicator lasts ten seconds and cannot be cancelled, only
+      // outlived: it is refreshed under that while the model is slow, and simply
+      // expires once the reply lands.
+      let typing: NodeJS.Timeout | null = null;
+      const showTyping = (): void => {
+        const channel = message.channel;
+        if (!("sendTyping" in channel)) return;
+        const send = () => void channel.sendTyping().catch(() => undefined);
+        send();
+        typing = setInterval(send, 8_000);
+      };
+
+      try {
         const parent = "parentId" in message.channel ? message.channel.parentId : null;
         const reply = await answerMention({
           channelId: message.channelId,
@@ -243,12 +281,18 @@ const runDaemon = async (args: {
           prompt: args.prompt,
           fallback: () => fallbackLine((max) => cryptoRandom.int(max)),
           onFallback: (reason) => log.warn("answered with a fallback line", { reason }),
+          onDecline: (reason) =>
+            log.debug("stayed quiet", { reason, userId: message.author.id, channelId: message.channelId }),
+          onThinking: showTyping,
         });
 
-      if (reply === null) return;
-      await message.reply({ content: reply, allowedMentions: { repliedUser: true, parse: [] } });
-      // Speaking is speaking: a passive cycle must not follow straight after a reply.
-      store.recordBotMessage(guildId, message.channelId, Date.now());
+        if (reply === null) return;
+        await message.reply({ content: reply, allowedMentions: { repliedUser: true, parse: [] } });
+        // Speaking is speaking: a passive cycle must not follow straight after a reply.
+        store.recordBotMessage(guildId, message.channelId, Date.now());
+      } finally {
+        if (typing !== null) clearInterval(typing);
+      }
     };
   }
 
@@ -269,7 +313,10 @@ const runDaemon = async (args: {
       const speakable = speakableChannels(guild, client.user.id).filter((c) =>
         channelAllowed(c.id, { deny: config.channels.deny, adminChannelId: config.channels.adminChannelId }, c.parentId),
       );
-      if (speakable.length === 0) return;
+      if (speakable.length === 0) {
+        log.debug("passive cycle: no channel is both speakable and allowed");
+        return;
+      }
 
       const known = new Map(store.channelActivity(guildId).map((a) => [a.channelId, a]));
       const candidates = speakable
@@ -303,14 +350,23 @@ const runDaemon = async (args: {
         });
         return;
       }
-      if (provider === null) return;
+      if (provider === null) {
+        log.debug("passive cycle: gates passed but no LLM provider is configured", { channelId });
+        return;
+      }
       log.info("passive cycle: gates passed, asking", { channelId });
 
       const channel = await guild.channels.fetch(channelId);
-      if (channel === null || !channel.isTextBased()) return;
+      if (channel === null || !channel.isTextBased()) {
+        log.debug("passive cycle: the chosen channel is gone or not text-based", { channelId });
+        return;
+      }
 
       const history = reduceHistory(await recentMessages(channel, config.conversation.mentionContextMessages));
-      if (history.length === 0) return;
+      if (history.length === 0) {
+        log.debug("passive cycle: nothing readable in the channel's recent history", { channelId });
+        return;
+      }
 
       const situation = await pakledSituation(
         guild,
@@ -329,7 +385,10 @@ const runDaemon = async (args: {
         return;
       }
 
-      if (await sendTo(guild, channelId, decision.response)) {
+      const spoken = await sendTo(guild, channelId, decision.response, (reason) =>
+        log.warn("could not speak unprompted", { channelId, reason }),
+      );
+      if (spoken) {
         store.recordBotMessage(guildId, channelId, Date.now());
         log.info("spoke unprompted", { channelId });
       }
@@ -486,7 +545,7 @@ const main = async (): Promise<number> => {
 
   const env = loadEnvironment();
   const config = loadConfig(env.dataDir);
-  const log = createLogger(config.logging.level);
+  const log = createLogger(env.logLevel ?? config.logging.level);
 
   // Generating golden samples needs no Discord connection at all.
   if (command === "golden") {
@@ -667,7 +726,12 @@ const main = async (): Promise<number> => {
             message = spokenLine.message;
           }
 
-          if (await withTimeout(sendTo(guild, channelId, message), BEAT_TIMEOUT_MS, false)) {
+          const sent = await withTimeout(
+            sendTo(guild, channelId, message, (reason) => log.warn("could not send a ceremony beat", { beat, reason })),
+            BEAT_TIMEOUT_MS,
+            false,
+          );
+          if (sent) {
             store.recordBotMessage(env.discordGuildId, channelId, Date.now());
             log.info("ceremony beat spoken", { beat });
           } else {

--- a/src/llm.test.ts
+++ b/src/llm.test.ts
@@ -214,4 +214,16 @@ describe("loadEnvironment", () => {
   it("still requires the Discord credentials", () => {
     expect(() => loadEnvironment({ DISCORD_GUILD_ID: "g" })).toThrow(/DISCORD_TOKEN/);
   });
+
+  it("leaves the log level to config.yaml when unset", () => {
+    expect(loadEnvironment(base).logLevel).toBeNull();
+  });
+
+  it("takes a log level override from the environment", () => {
+    expect(loadEnvironment({ ...base, PAKLED_LOG_LEVEL: " DEBUG " }).logLevel).toBe("debug");
+  });
+
+  it("refuses a log level it does not recognise rather than logging at the wrong one", () => {
+    expect(() => loadEnvironment({ ...base, PAKLED_LOG_LEVEL: "verbose" })).toThrow(/PAKLED_LOG_LEVEL/);
+  });
 });

--- a/src/mentions.test.ts
+++ b/src/mentions.test.ts
@@ -116,6 +116,27 @@ describe("answerMention", () => {
     expect(await answering()).toBe("We need the helmets.");
   });
 
+  it("says why it stayed quiet, so silence can be told apart from a dead bot", async () => {
+    const reasons: string[] = [];
+    const userCooldown = createCooldown(1000);
+    await answering({ channels: { deny: ["c1"], adminChannelId: null }, onDecline: (r) => reasons.push(r) });
+    await answering({ question: "  ", onDecline: (r) => reasons.push(r) });
+    await answering({ userCooldown });
+    await answering({ userCooldown, now: 100, onDecline: (r) => reasons.push(r) });
+    expect(reasons).toEqual([
+      "channel is denied or is the admin channel",
+      "nothing was asked once the mention was stripped",
+      "user is within the mention cooldown",
+    ]);
+  });
+
+  it("shows it is thinking only once a model is actually going to be asked", async () => {
+    const thinking: string[] = [];
+    await answering({ onThinking: () => thinking.push("asked") });
+    await answering({ question: "  ", onThinking: () => thinking.push("declined") });
+    expect(thinking).toEqual(["asked"]);
+  });
+
   it("ignores a mention in a denied channel", async () => {
     expect(await answering({ channels: { deny: ["c1"], adminChannelId: null } })).toBeNull();
   });

--- a/src/mentions.ts
+++ b/src/mentions.ts
@@ -102,14 +102,34 @@ export const answerMention = async (args: {
   prompt: string;
   fallback: () => string;
   onFallback?: (reason: string) => void;
+  /** Why the bot stayed quiet. Silence has four causes and they are indistinguishable from outside. */
+  onDecline?: (reason: string) => void;
+  /**
+   * Fired once the gates have passed and a model is about to be asked — never
+   * before, or the bot would appear to be typing an answer it has already decided
+   * not to give.
+   */
+  onThinking?: () => void;
 }): Promise<string | null> => {
-  if (!channelAllowed(args.channelId, args.channels, args.parentId)) return null;
-  if (args.question.trim().length === 0) return null;
+  if (!channelAllowed(args.channelId, args.channels, args.parentId)) {
+    args.onDecline?.("channel is denied or is the admin channel");
+    return null;
+  }
+  if (args.question.trim().length === 0) {
+    args.onDecline?.("nothing was asked once the mention was stripped");
+    return null;
+  }
   // Per user, so one person cannot monopolise the bot by mentioning it repeatedly.
-  if (!args.userCooldown.allow(args.userId, args.now)) return null;
+  if (!args.userCooldown.allow(args.userId, args.now)) {
+    args.onDecline?.("user is within the mention cooldown");
+    return null;
+  }
   // Per channel, because a per-user cooldown does nothing against a crowd, and every
   // answer costs a paid request.
-  if (args.channelCooldown !== undefined && !args.channelCooldown.allow(args.channelId, args.now)) return null;
+  if (args.channelCooldown !== undefined && !args.channelCooldown.allow(args.channelId, args.now)) {
+    args.onDecline?.("channel is within the channel cooldown");
+    return null;
+  }
 
   // No provider configured: still answer, in the character's own words.
   if (args.provider === null) {
@@ -117,6 +137,7 @@ export const answerMention = async (args: {
     return args.fallback();
   }
 
+  args.onThinking?.();
   try {
     const request = replyRequest(args.prompt, await args.context(), await args.history(), args.question);
     const { message, usedFallback } = parseSpoken(await args.provider.complete(request), args.fallback());


### PR DESCRIPTION
Answers the question this bot could not answer: why did it not reply?

## Silence now has a reason

`answerMention` declined on four paths — denied channel, empty question, user
cooldown, channel cooldown — all returning `null` with no log at any level. An
ignored mention was indistinguishable from a dead process. Each gate now reports
its reason through an `onDecline` hook, and a recognised mention is logged on
arrival, so a missing `mentioned` line means the mention never reached the bot
(a reply with its ping off, or a role mention, never populates `mentions.users`).

## Gateway lifecycle

There was none. Disconnects log with their close code, resumes log
`replayedEvents` — messages sent during a gateway gap are never delivered, which
is usually the real answer when the bot appears to ignore someone.

## `sendTo` no longer swallows failures

It caught everything and returned `false` in silence: the bot could decide to
speak, fail, and log nothing. It takes an `onError` now, wired at both call
sites. The passive cycle's four remaining silent exits report themselves too.

## Grunk is typing

A typing indicator while the model composes, refreshed under Discord's
ten-second expiry, started only after every gate passes so the bot never appears
to type an answer it has already decided not to give.

## `PAKLED_LOG_LEVEL`

Overrides `logging.level`, so raising the level on a running container is a
restart rather than an edit to the config file it mounts. An unrecognised value
fails at startup rather than quietly logging at the wrong one.

Deliberately skipped: typing on passive interjections (the model usually
declines, so it would be typing followed by silence), a per-tick "ceremony not
due" line (1440/day, and every state transition already logs at info), and
discord.js's `Events.Debug` firehose.

Typecheck clean, 257 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)