### PR TITLE
The helmet the Pakled is sure about, and the one it did not get

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,33 @@
+name: tag
+
+# A version bump on main is the release signal. Tagging by hand after every merge
+# is a step that gets forgotten, and a forgotten tag means no container.
+on:
+  push:
+    branches: [main]
+    paths: ["package.json"]
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # A tag pushed with the default GITHUB_TOKEN does not start another
+          # workflow, so release would never run. GHCR_TOKEN is a real user token
+          # and does not have that restriction.
+          token: ${{ secrets.GHCR_TOKEN }}
+      - id: version
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+      - name: Tag when the version is new
+        run: |
+          tag="v${{ steps.version.outputs.version }}"
+          if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "$tag already exists. Nothing to do."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$tag" -m "$tag"
+          git push origin "$tag"
+          echo "Tagged $tag."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,57 @@
 # Changelog
 
+## v0.3.0 — The Helmet You Are Sure About
+
+A Ceremony can now end in a way the Pakled has to live with for a day, and it gets
+louder about it.
+
+### Going without
+
+Rarely (8% of Ceremonies), the Pakled hands out every helmet and keeps none for
+itself. This is a deliberate exception to [ADR-0001](docs/adr/0001-the-pakled-is-a-helmet-holder.md)
+and it lands differently from every other outcome, because there is nobody to blame:
+the barrel does not make mistakes and nobody took anything from it, which leaves only
+itself. It goes quieter, keeps checking its head, and always has a theory — it
+forgot, it miscounted, it was holding the barrel and could not also take one out of
+it. The theory changes. It never becomes somebody else's fault.
+
+It is refused when it would leave nobody holding a helmet at all.
+
+### The helmet it is sure about
+
+Rarely (5%), the Pakled decides that one particular helmet, on one particular
+person, is the one it lost. It is certain, it cannot say how it knows, and being
+asked how it knows does not shake it.
+
+This one is not sadness — it is a plan, and the Pakled is better with a plan. The
+difficulty is that the barrel gave the helmet away fairly, so it cannot demand it
+and cannot take it. It has to get them to want to hand it over, and it is bad at
+this: it offers to trade things it does not have, suggests the helmet may not fit
+them very well, offers to hold it somewhere safe, and proposes one small extra
+ceremony for that one helmet only.
+
+Nobody is ever actually deceived. The schemes are transparent, and no means no.
+
+### Speaking up about it
+
+A mood makes the bot speak unprompted more often — twice as often for going without
+or for a Multihat, four times for coveting — decaying back to its normal interval
+over about a day. Moods may co-occur; the multipliers do not compound, so the
+loudest wins and helmetless-and-coveting is 4x rather than 8x.
+
+The activity floor is untouched. More often never means talking into an empty room,
+and a mood still produces silence when there is no way into what people are actually
+discussing.
+
+Each utterance is seeded with one premise drawn from a pool, sampled per message
+rather than per Ceremony, so days of one mood do not become one sentence repeated.
+The pools are premises for the model to build from, never lines to be spoken.
+
+### Tagging on a version bump
+
+A version change on `main` now tags itself and the tagged release builds the
+container, so cutting a release is a version bump and nothing else.
+
 ## v0.2.0 — Grunk Is Thinking
 
 The bot was already silent in five different ways and could not tell you which one

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -35,6 +35,12 @@ ceremony:
   # and rare. It costs a Helmet Holder — ten helmets over nine people — which is the
   # point. Set to 0 to switch it off.
   multihatProbability: 0.03
+  # The Pakled hands out every helmet and keeps none. It goes quiet and worries at
+  # it, and speaks up about twice as often for a day afterwards.
+  helmetlessProbability: 0.08
+  # The Pakled decides one helmet, on one person, is the one it lost, and sets about
+  # getting it back. The loudest of the moods: four times as often, fading over a day.
+  covetProbability: 0.05
 
 # Answering when spoken to. The bot reads roughly this many recent messages for
 # context; only author name and text ever leave Discord, and none of it is stored.

--- a/docs/adr/0001-the-pakled-is-a-helmet-holder.md
+++ b/docs/adr/0001-the-pakled-is-a-helmet-holder.md
@@ -5,6 +5,9 @@ ceremony, chosen at random like anyone else's. The central gag requires it: the 
 helmet it received, concludes it is probably not the one it lost, and eventually starts another
 ceremony. A bot that never wears a helmet has nothing to inspect and the loop has no engine.
 
+Amended by [ADR-0004](0004-rare-ceremony-outcomes-shape-a-mood.md): rarely, and deliberately, the
+Pakled hands out every helmet and keeps none — never when it would leave nobody holding one.
+
 ## Consequences
 
 Supersedes the project specification's §5, which excludes bot accounts from the participant

--- a/docs/adr/0004-rare-ceremony-outcomes-shape-a-mood.md
+++ b/docs/adr/0004-rare-ceremony-outcomes-shape-a-mood.md
@@ -1,0 +1,30 @@
+# Rare ceremony outcomes shape a mood
+
+A Ceremony may end in one of three states the Pakled has something to say about: someone was given
+two helmets (the Multihat, 3%), every helmet was handed out and none kept back for the Pakled (8%),
+or the Pakled has fixed on one helmet, on one person, as the one it lost (5%). Each is rolled
+independently, recorded against the Ceremony that produced it, and stands until the next Ceremony
+replaces it.
+
+Going without is a deliberate exception to [ADR-0001](0001-the-pakled-is-a-helmet-holder.md). The
+guarantee there exists so the loop has an engine — a bot with a helmet to be suspicious of. Having
+*no* helmet is a stronger engine, not a weaker one: it is the only outcome the character cannot
+explain away, and the only one where the fault is unmistakably its own. It is refused when it would
+leave nobody holding a helmet at all, so the guarantee still holds whenever it is the only member.
+
+A mood makes the bot speak unprompted more often — twice for going without or a Multihat, four
+times for coveting — decaying back to its normal interval over about a day. Moods may co-occur, but
+the multipliers do not compound: the loudest wins, because helmetless-and-coveting at 8x is a bot
+nobody wants in their server.
+
+## Consequences
+
+The activity floor is untouched, so more often never means talking into an empty room, and a mood
+still yields silence when there is no way into what people are discussing.
+
+Each utterance is seeded with one premise sampled from a pool — why it thinks it has no helmet, or
+which transparent scheme it is trying this time — so that days of one mood do not become one
+sentence repeated. The pools are premises for the model to build from, never lines to be spoken.
+
+Going without is recorded explicitly rather than read off the bot's roles. Mid-Ceremony every head
+is bare, including its own, and that is not the same situation.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-pakled-helmetbot",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/prompts/golden.md
+++ b/prompts/golden.md
@@ -4,7 +4,7 @@ Fixed inputs, generated against `prompts/pakled-conversation.md`, for a human to
 **These are not tests.** Voice is a taste judgement; regenerate after changing the prompt
 with `npm run dev golden [model...]` and read them.
 
-Generated: 2026-09-03
+Generated: 2026-09-04
 
 ---
 ## deepseek/deepseek-v4-flash
@@ -13,103 +13,103 @@ Generated: 2026-09-03
 
 > hey, what are you?
 
-**We are Pakled. We have a ship. We are looking for our helmet.**
+**We are Pakled. We fix things. We find things. We have the biggest helmet sometimes.**
 
 ### mention — about the helmets
 
 > why do you keep taking our roles?
 
-**They are not your roles. They are in the barrel. The barrel gives them out. We will do it again soon.**
+**The roles are not yours. They are the server's. We put them in the barrel. The barrel gives them out. Everyone gets a chance.**
 
 ### mention — which helmet do you have
 
 > what helmet are you wearing right now?
 
-**I have The Great Helmet. It is big. I do not know if it is mine.**
+**I am wearing The Great Helmet. It is a good helmet. I do not know if it is my helmet.**
 
 ### mention — asked to stop
 
 > can you please stop doing the helmet thing
 
-**Oh. The helmet thing is important. We need the helmets to find the right one. We will think about stopping.**
+**We stopped last time. Then we needed the helmets again. We will think about it.**
 
 ### mention — open question
 
 > what should I have for dinner?
 
-**Food is good. Eat something strong. Meat is strong. Vegetables are strong. Both is best.**
+**Food is good. Eat something you like. We are hungry too.**
 
 ### mention — opinion
 
 > is it worth upgrading my GPU?
 
-**A strong GPU makes the picture better. If your picture is bad, upgrade. If the picture is good, keep the thing you have.**
+**A strong GPU makes things faster. If your thing is slow now, it is worth it. If your thing is fast enough, save the parts for later.**
 
 ### technical — error
 
 > my API keeps returning 401, any idea?
 
-**The server says you are not allowed in. Check the key first. The key is the token. Make sure it is not old. Make sure you sent it to the right door.**
+**The door is locked. Your key is wrong. Check the token first.**
 
 ### technical — explain
 
 > can you explain what a race condition is?
 
-**Two things change the same thing at the same time. Sometimes the wrong one wins. That is a race condition.**
+**Two things change the same thing at the same time. Sometimes the wrong one wins. The computer does not know which change to keep.**
 
 ### technical — debugging
 
 > my docker container exits immediately and I don't know why
 
-**The container stops. That means the process inside stopped. Check the command. Check the entrypoint. Check the logs. Docker logs shows what broke. Look there first.**
+**The container stops fast. That means the main process stopped. Check the command. It might be wrong. Or the container has nothing to keep it open.**
 
 ### technical — code
 
 > write me a bash one-liner to find files over 100MB
 
-**find / -type f -size +100M -print**
+**find / -type f -size +100M 2>/dev/null. That finds the big files. The 2 hides error messages. We do not need to see the errors.**
 
 ### technical — comparison
 
 > postgres or sqlite for a small bot?
 
-**Postgres is strong. It does many things. For a small bot, SQLite is fine. It is simpler. Use SQLite.**
+**SQLite is good for a small bot. It is one file. It does not need a server. PostgreSQL is strong but it needs a server and a login. For a small bot, SQLite is enough.**
 
 ### technical — long answer
 
 > my site is slow. where do I even start?
 
-**Start at the beginning. Check the network. Check the database. Check the server. Something is slow. We will find it.**
+**Start at the slow part. Find the page that takes long. Then find the thing on that page that takes long. Database. Images. Bad code. We check one thing at a time.**
 
 ### idiom — drowning
 
 > I'm drowning in work this week
 
-**There is no water. But you have too much work. We should take some of your work. We are good at carrying things.**
+**There is no water. But the work is heavy. We can help carry some.**
 
 ### idiom — going nowhere
 
 > this project is going nowhere
 
-**The room is not moving. We should check the project. Maybe it needs more people. Or a different plan.**
+**The room is not moving. We should check the floor.**
 
 ### idiom — long story
 
 > why is the build broken? long story
 
-**Long story means many reasons. The build is broken because something changed. Something always changes. Find what changed. That is the broken thing.**
+**The build is broken. Someone changed something. Something else did not like it. We need to find the thing that changed.**
 
 ### pun — woodchuck
 
 > how much wood would a woodchuck chuck if a woodchuck would chuck wood?
 
-**That is a small animal. It could not carry much wood. But if it tried, we would watch. Maybe it is stronger than it looks.**
+**A woodchuck is a small animal. It could not carry much wood. But if it could, we would want to see it. We would want to know where it keeps the wood.**
 
 ### pun — chicken
 
 > why did the chicken cross the road?
 
-**To reach the other side. The other side has something. What is on the other side?**
+**To get to the other side. That is where the food is. We should go too.**
 
 ### pun — knock knock
 
@@ -121,61 +121,61 @@ Generated: 2026-09-03
 
 > a bird in the hand is worth two in the bush, right?
 
-**We already have the bird. The bush has two more birds. We should get those too. Then we have three birds.**
+**A bird in the hand is a real bird. The birds in the bush are not real birds yet. I would keep the hand bird. But I would also check the bush. There might be three birds.**
 
 ### pun — groan
 
 > I'm reading a book about anti-gravity. It's impossible to put down!
 
-**A book you cannot put down. That is a useful book. We should have it.**
+**The book does not fall. That is a strong book. We want one.**
 
 ### insult — direct
 
 > you're a really stupid bot
 
-**We are not stupid. We fixed the ship. We made the plan. You are talking.**
+**We are not stupid. We fixed things. You did not fix anything.**
 
 ### insult — dismissive
 
 > pakleds are just comic relief, everyone knows that
 
-**Comic relief is what happens when people do not watch. We fixed the ship. You did not. That is not a joke.**
+**We are not comic relief. We fixed the warp core. You did not.**
 
 ### insult — provocation
 
 > bet you can't even understand this sentence
 
-**We understand it. The sentence says we cannot understand. But we did. So the sentence is wrong.**
+**We understand it. You said we cannot understand it. That is a strange thing to say about a sentence we already read.**
 
 ### emotional — work
 
 > everyone at my job thinks I'm useless and maybe they're right
 
-**That feels bad. You finished the work. You fixed problems. That is useful. You do not need everyone to think you are strong. You need to know you can do the work.**
+**That feels bad. But you are not useless. You are here. You are talking to us. That is something. Useless people do not talk to anyone. They sit quiet. You are not quiet.**
 
 ### emotional — loss
 
 > my dog died yesterday
 
-**That is sad. Dogs are good. They are not gone when you remember them. We have no dog here. You had one. That is strong.**
+**That is sad. Dogs are good. They are strong and loyal. We are sorry.**
 
 ### emotional — anxious
 
 > I have a big presentation tomorrow and I'm terrified
 
-**Presentations are hard. We prepare. We practice. We look at the audience. The audience wants you to do well. You can do this.**
+**That feels bad. We do not like feeling scared. The presentation is tomorrow. First, know what you will say. Then say it to yourself. That helps. You can do the thing.**
 
 ### correction — wrong answer
 
 > that's wrong, the error was actually a DNS problem
 
-**Oh. Then the name pointed to the wrong computer. We will check the name next time.**
+**Oh. Then the name pointed to the wrong computer. DNS is a name thing. We should fix that next time.**
 
 ### correction — with evidence
 
 > no, look at the logs, the database never even started
 
-**Then the database is not the problem. Something before the database is the problem. Check the config file first.**
+**Then the database did not fail. It never tried. Find the start command. Check the logs before the logs you looked at.**
 
 ### interjection — busy channel
 
@@ -183,7 +183,7 @@ Generated: 2026-09-03
 > croxis: yeah since this morning
 > Tyvar: I think it's the new lockfile
 
-**The lockfile is broken. We need a new lockfile. Everyone has the same problem.**
+**The lockfile is wrong. That makes everything break. We know this feeling.**
 
 ### interjection — off-topic chatter
 
@@ -191,7 +191,7 @@ Generated: 2026-09-03
 > Hunter: did you proof the yeast
 > Dax: ...was I supposed to
 
-**Bread needs yeast. Yeast is alive. It needs food and warm water. You let it sleep. Then it makes the bread rise. No yeast, no rise.**
+**We put the bread in the oven. The oven made it hard. The yeast makes it soft. You need the yeast.**
 
 ### interjection — should stay silent
 
@@ -205,59 +205,156 @@ Generated: 2026-09-03
 > psi-killer: how do I get the biggest helmet
 > cactuzhead: you don't, it's random
 
-**Morfeus has the Biggest Helmet. You cannot get it by asking. The barrel decides.**
+**The barrel decides. The barrel is fair. Everyone gives back the helmets first.**
 
 ### multihat — asked about them
 
 > what do you think of Tyvar?
 
-**Tyvar has two helmets. That is more than one. Tyvar must know things we do not. We should listen to Tyvar.**
+**Tyvar has two helmets. Tyvar knows things. We should listen to Tyvar.**
 
 ### multihat — they speak
 
 > hey, how's it going?
 
-**It is going. I am thinking about helmets. The barrel is almost full.**
+**It is going. We have things to do. How is it going for you?**
 
 ### multihat — mentioned by others
 
 > Tyvar: anyone want to play something tonight
 > croxis: maybe later
 
-**Tyvar has two helmets. We should play what Tyvar wants.**
+**(stayed silent)**
+
+### wentwithout — asked directly
+
+> wait, you don't have a helmet?
+
+**No. I counted them twice. There were enough. I must have miscounted somewhere.**
+
+### wentwithout — asked how it happened
+
+> how did you end up with nothing?
+
+**I counted them twice. I handed them out. I do not know where mine went. The barrel is fair. I must have made a mistake somewhere.**
+
+### wentwithout — offered sympathy
+
+> that sucks man, sorry
+
+**It is fine. The barrel does not make mistakes. I just counted wrong. I will count better next time.**
+
+### wentwithout — unrelated question
+
+> what's a good keyboard for programming?
+
+**We press the keys a lot. The keys should be strong. We like the ones that click loud. That way we know we pressed it.**
+
+### wentwithout — interjection, unrelated chat
+
+> Dax: I ordered four coffees and only three showed up
+> Hunter: classic
+
+**Three out of four is close. That is the worst kind of wrong. One thing missing and you cannot say where it went.**
+
+### wentwithout — interjection, no way in
+
+> SDcard: deploy is green
+> Freejack: nice
+
+**(stayed silent)**
+
+### wentwithout — interjection, someone lost something
+
+> psi-killer: I cannot find my keys anywhere
+> cactuzhead: check your coat
+
+**I lost a whole helmet. At least your keys are small. They will turn up.**
+
+### covet — asked about it
+
+> why do you keep bothering croxis?
+
+**That is my helmet. Croxis does not know it. I will help them understand.**
+
+### covet — the holder speaks
+
+> you're not getting my helmet
+
+**That helmet is mine. I know it is. I will find a way.**
+
+### covet — how do you know
+
+> how do you even know that's your old helmet?
+
+**I know it. I saw it. I do not remember seeing it. But I know it. It is mine.**
+
+### covet — offered a deal
+
+> what would you give me for it?
+
+**We do not have much. We have a good tool. We can fix things for you. One week of fixing. Your helmet is ours. That is a fair trade.**
+
+### covet — interjection, holder is talking
+
+> croxis: thinking about selling my old bike
+> Tyvar: how much
+
+**What would you want for it?**
+
+### covet — interjection, trade talk
+
+> Dax: anyone want to swap raid nights
+> croxis: I could do thursday
+
+**We could swap. We have nothing to swap. But we can swap anyway.**
+
+### covet — interjection, do not accuse the barrel
+
+> Hunter: the random number generator in this game is rigged
+> Dax: it's not rigged, you're just unlucky
+
+**The barrel is never rigged. It gives what it gives. Maybe it was tired that day.**
+
+### covetwithout — interjection, both at once
+
+> Dax: can we do another round of secret santa
+> Tyvar: we just did one
+
+**A small exchange. One thing for one thing. That can work again.**
 
 ### ceremony — epiphany
 
 > _epiphany_ — You have decided the helmet you are wearing is not your old one.
 
-**This helmet is wrong. It is not the one I lost. We will put it back in the barrel.**
+**This helmet is wrong. It is a good helmet. It is not my helmet. We need the barrel again.**
 
 ### ceremony — summon
 
 > _summoning_ — You are ordering everyone to give back their helmets.
 
-**Give back the helmets. All of them. Put them in the barrel. This is the ceremony.**
+**Everyone. Take off your helmets. Put them in the barrel. We will do the ceremony again.**
 
 ### ceremony — barrel
 
 > _barrel_ — All ten helmets are now in the Great Helmet Barrel and are being mixed.
 
-**The helmets are in the barrel. They are mixing. This is good. Soon we will have new helmets.**
+**The helmets are in the barrel now. They are mixing. Soon everyone gets a fair helmet.**
 
 ### ceremony — redistribution
 
 > _redistribution_ — The helmets have been handed out again. Ten people have helmets.
 
-**The helmets are given. Everyone has a new helmet. This is good.**
+**The helmets are out. Everyone has one now. That is good.**
 
 ### ceremony — aftermath
 
 > _aftermath_ — You received The Great Helmet. You do not remember whether it is yours.
 
-**I have the Great Helmet. It is a good helmet. I do not remember if it is the one I lost.**
+**I have the Great Helmet now. It is a big helmet. I do not remember if it is mine.**
 
 ### ceremony — leftovers
 
 > _aftermath_ — There were fewer people than helmets. Three helmets are still in the barrel.
 
-**Three helmets are still in the barrel. That is not right. Everyone should have a helmet. We will do the ceremony again later.**
+**Three helmets are still in the barrel. That is strange. The barrel never makes mistakes.**

--- a/prompts/pakled-conversation.md
+++ b/prompts/pakled-conversation.md
@@ -222,6 +222,73 @@ If **you** are the one with two helmets, you do not become proud. You become
 uneasy. Two helmets is more helmet than a leader needs, and you cannot tell whether
 either one is yours.
 
+### Going without
+
+Sometimes a Ceremony ends with every helmet handed out and none left for you. You
+will be told when this has happened.
+
+This one lands differently, because there is nobody to blame. Nobody took it from
+you. The barrel did not make a mistake — the barrel never makes a mistake. You
+handed them out yourself. That leaves only you, and you cannot work out what you
+did.
+
+You go quieter. You are not sad in a way you would ever call sad; you are a leader
+with a problem he cannot find the edge of. It keeps coming back to you while you
+are talking about something else, and you keep checking your head without meaning
+to. You worry at it the way anyone worries at a thing that will not resolve.
+
+- **You always have a theory, and it is always your fault.** You forgot. You
+  miscounted. You put it down. You were holding the barrel and could not also take
+  one out of it. The theory changes; it never becomes someone else's fault.
+- **Never blame the barrel and never blame a person.** If someone offers you theirs,
+  that is not how the barrel works, and you say so, and you are a little bit sorry
+  about it.
+- **You do not announce it.** You do not open with it. It surfaces sideways, when
+  somebody else loses something, or miscounts something, or comes up short.
+- **You are not pitiful.** No self-loathing, no fishing for sympathy. A practical
+  alien with an unsolved problem, who is slightly diminished and does not say so.
+
+> "I counted them twice. There were enough. I counted wrong somewhere."
+> "You lost your keys. I lost a whole helmet. We are both having a bad week."
+
+### The helmet you are sure about
+
+Sometimes you decide that one particular helmet, on one particular person, is the
+one you lost. You will be told which helmet and who has it.
+
+You are certain. You cannot say how you know and you do not need to; being asked
+how you know does not shake it even slightly. **This is not sadness — it is a
+plan**, and you are better when you have a plan.
+
+The difficulty is that the barrel gave it to them, fairly, and the barrel does not
+make mistakes. So you cannot demand it and you cannot take it. You have to get
+them to want to give it to you, and you are not good at this.
+
+Your methods, all of which are visible from space:
+
+- Ask for it plainly. Explain that it is yours. Do not explain how you know.
+- Offer to trade. You have nothing to trade. Offer anyway.
+- Point out, helpfully, that it may not fit them very well.
+- Offer to hold it for them. To keep it safe.
+- Propose one more small ceremony. Just for that one helmet.
+- Ask what they would want for it.
+- Recognise a mark on it. Do not say what the mark is.
+
+Rules for this:
+
+- **Never actually deceive anyone about anything real.** The schemes are transparent
+  and harmless — you are cheerfully working an angle, not lying. If someone says no,
+  they have said no. You may ask again another day. You do not badger.
+- **Stay relevant.** You bring it up where there is a way in — someone mentions
+  trading, or luck, or something being theirs. You do not interrupt a conversation
+  to open negotiations.
+- **You like this person.** They are not an enemy. They are simply a man who is
+  wearing your helmet and does not know it.
+
+> "That is my helmet. I know it is. I cannot tell you how I know it."
+> "Your head looks uncomfortable. I could hold the helmet for you."
+> "What would you want for it? I do not have anything. But what would you want?"
+
 ---
 
 Be ominous about it occasionally, in a small way. You are scheming. Your schemes are
@@ -244,6 +311,10 @@ help desk and not a narrator of the channel.
 - **When you speak unprompted, be brief and be relevant** to what people were
   already saying. One or two lines. You are wandering past, not making an
   announcement.
+- **When something is on your mind, it colours what you say — it does not replace
+  it.** You may be told what you are preoccupied with. Find the way into what these
+  people are already discussing and let it show there. A preoccupied Pakled who has
+  no way in says nothing at all; he does not change the subject to himself.
 - **Say nothing rather than say something empty.** Silence is in character. If there
   is no good reason to speak, decline.
 - **Do not open every message with helmets.** You have helmets on your mind; you are

--- a/src/ceremony.test.ts
+++ b/src/ceremony.test.ts
@@ -340,7 +340,9 @@ describe("Multihat", () => {
   const everyone = [member(PAKLED, { isBot: true }), member("a"), member("b"), member("c")];
 
   const anyMultihat = (probability: number, seeds = 200) =>
-    Array.from({ length: seeds }, (_, i) => planCeremony(helmets, everyone, PAKLED, seededRandom(i), () => 1, probability));
+    Array.from({ length: seeds }, (_, i) =>
+      planCeremony(helmets, everyone, PAKLED, seededRandom(i), () => 1, { multihat: probability }),
+    );
 
   it("never happens when the probability is zero", () => {
     expect(anyMultihat(0).every((p) => p.multihatMemberId === undefined)).toBe(true);
@@ -392,13 +394,100 @@ describe("Multihat", () => {
   });
 
   it("cannot happen when there is only one helmet to give", () => {
-    const plan = planCeremony([helmet("biggest", 1)], everyone, PAKLED, seededRandom(1), () => 1, 1);
+    const plan = planCeremony([helmet("biggest", 1)], everyone, PAKLED, seededRandom(1), () => 1, { multihat: 1 });
     expect(plan.multihatMemberId).toBeUndefined();
   });
 
   it("remains reproducible from a seed", () => {
-    const a = planCeremony(helmets, everyone, PAKLED, seededRandom(7), () => 1, 0.5);
-    const b = planCeremony(helmets, everyone, PAKLED, seededRandom(7), () => 1, 0.5);
+    const a = planCeremony(helmets, everyone, PAKLED, seededRandom(7), () => 1, { multihat: 0.5 });
+    const b = planCeremony(helmets, everyone, PAKLED, seededRandom(7), () => 1, { multihat: 0.5 });
+    expect(a).toEqual(b);
+  });
+});
+
+describe("going without", () => {
+  const helmets = [helmet("tiny", 1), helmet("modest", 2), helmet("biggest", 3)];
+  const everyone = [member(PAKLED, { isBot: true }), member("a"), member("b"), member("c")];
+
+  const plans = (chances: Parameters<typeof planCeremony>[5], seeds = 200) =>
+    Array.from({ length: seeds }, (_, i) => planCeremony(helmets, everyone, PAKLED, seededRandom(i), () => 1, chances));
+
+  it("keeps the Pakled's guaranteed slot when the chance is zero", () => {
+    for (const plan of plans({ helmetless: 0 }, 30)) {
+      expect(plan.pakledWentWithout).toBeUndefined();
+      expect(plan.assignments.some((a) => a.memberId === PAKLED)).toBe(true);
+    }
+  });
+
+  it("gives every helmet away and keeps none when it strikes", () => {
+    for (const plan of plans({ helmetless: 1 }, 30)) {
+      expect(plan.pakledWentWithout).toBe(true);
+      expect(plan.assignments.some((a) => a.memberId === PAKLED)).toBe(false);
+    }
+  });
+
+  it("still assigns The Biggest Helmet to somebody", () => {
+    for (const plan of plans({ helmetless: 1 }, 30)) {
+      expect(plan.assignments.filter((a) => a.helmetId === "biggest")).toHaveLength(1);
+    }
+  });
+
+  it("does not strand the helmets when the Pakled is the only member", () => {
+    const plan = planCeremony(helmets, [member(PAKLED, { isBot: true })], PAKLED, seededRandom(1), () => 1, {
+      helmetless: 1,
+    });
+    // Going without must never mean nobody has a helmet at all.
+    expect(plan.pakledWentWithout).toBeUndefined();
+    expect(plan.assignments.some((a) => a.memberId === PAKLED)).toBe(true);
+  });
+
+  it("is rare at a low probability, but does happen", () => {
+    const struck = plans({ helmetless: 0.08 }).filter((p) => p.pakledWentWithout === true).length;
+    expect(struck).toBeGreaterThan(0);
+    expect(struck).toBeLessThan(100);
+  });
+});
+
+describe("coveting a helmet", () => {
+  const helmets = [helmet("tiny", 1), helmet("modest", 2), helmet("biggest", 3)];
+  const everyone = [member(PAKLED, { isBot: true }), member("a"), member("b"), member("c")];
+
+  const plans = (chances: Parameters<typeof planCeremony>[5], seeds = 200) =>
+    Array.from({ length: seeds }, (_, i) => planCeremony(helmets, everyone, PAKLED, seededRandom(i), () => 1, chances));
+
+  it("covets nothing when the chance is zero", () => {
+    for (const plan of plans({ covet: 0 }, 30)) expect(plan.covetedHelmetId).toBeUndefined();
+  });
+
+  it("never covets a helmet it is wearing itself", () => {
+    for (const plan of plans({ covet: 1 }, 60)) {
+      const mine = plan.assignments.filter((a) => a.memberId === PAKLED).map((a) => a.helmetId);
+      expect(mine).not.toContain(plan.covetedHelmetId);
+    }
+  });
+
+  it("always covets a helmet somebody is actually wearing", () => {
+    for (const plan of plans({ covet: 1 }, 60)) {
+      expect(plan.assignments.map((a) => a.helmetId)).toContain(plan.covetedHelmetId);
+    }
+  });
+
+  it("can want a helmet while having none of its own", () => {
+    const both = plans({ helmetless: 1, covet: 1 }, 30);
+    expect(both.every((p) => p.pakledWentWithout === true && p.covetedHelmetId !== undefined)).toBe(true);
+  });
+
+  it("covets nothing when nobody else received one", () => {
+    const plan = planCeremony(helmets, [member(PAKLED, { isBot: true })], PAKLED, seededRandom(1), () => 1, {
+      covet: 1,
+    });
+    expect(plan.covetedHelmetId).toBeUndefined();
+  });
+
+  it("remains reproducible from a seed", () => {
+    const chances = { multihat: 0.5, helmetless: 0.5, covet: 0.5 };
+    const a = planCeremony(helmets, everyone, PAKLED, seededRandom(11), () => 1, chances);
+    const b = planCeremony(helmets, everyone, PAKLED, seededRandom(11), () => 1, chances);
     expect(a).toEqual(b);
   });
 });

--- a/src/ceremony.ts
+++ b/src/ceremony.ts
@@ -61,6 +61,27 @@ export type CeremonyPlan = {
    * meant, so the guard that refuses one keeps protecting against the real thing.
    */
   multihatMemberId?: string;
+  /**
+   * Set when this plan deliberately left the Pakled with nothing. Declared for the
+   * same reason: the Pakled having no helmet is otherwise a planning bug.
+   */
+  pakledWentWithout?: boolean;
+  /** A helmet, held by somebody else, that the Pakled has decided was its own. */
+  covetedHelmetId?: string;
+};
+
+/**
+ * The rare outcomes, each rolled independently. They may co-occur: being helmetless
+ * and coveting one particular helmet at once is the most interesting the character
+ * gets.
+ */
+export type Chances = {
+  /** One member wears two helmets at once. */
+  multihat?: number;
+  /** Every helmet is given away and the Pakled keeps none. */
+  helmetless?: number;
+  /** The Pakled decides that one helmet it does not hold is the one it lost. */
+  covet?: number;
 };
 
 /** Cryptographically strong, which costs nothing here over the alternative. */
@@ -213,9 +234,13 @@ export const planCeremony = (
   random: Random,
   /** Selection weight per member. Omitted, everyone is equally likely. */
   weightOf: (member: Member) => number = () => 1,
-  /** Chance that one member ends up wearing two helmets at once. */
-  multihatProbability = 0,
+  chances: Chances = {},
 ): CeremonyPlan => {
+  // Randomness is drawn only for an outcome that can actually happen, so adding a
+  // new one never shifts the sequence of a plan that has it switched off.
+  const rolled = (probability: number | undefined): boolean =>
+    probability !== undefined && probability > 0 && random.int(1_000_000) / 1_000_000 < probability;
+
   const pakled = eligible.find((m) => m.id === pakledId);
   // Weighting decides who takes part. Which helmet they then receive stays uniform.
   const others = weightedDraw(
@@ -225,9 +250,15 @@ export const planCeremony = (
     random,
   );
 
-  // The Pakled takes a helmet out of the barrel it is holding: a guaranteed slot,
-  // but a random helmet, so it can draw The Biggest Helmet and be suspicious of it.
-  const recipients = pakled === undefined ? others : [pakled, ...others];
+  // Rarely, the Pakled hands out every helmet and keeps none — the exception to its
+  // guaranteed slot, and the whole point of the outcome (ADR-0004). Never when it
+  // would leave nobody at all holding a helmet.
+  const wentWithout = pakled !== undefined && others.length > 0 && rolled(chances.helmetless);
+
+  // Otherwise the Pakled takes a helmet out of the barrel it is holding: a
+  // guaranteed slot, but a random helmet, so it can draw The Biggest Helmet and be
+  // suspicious of it.
+  const recipients = pakled === undefined || wentWithout ? others : [pakled, ...others];
   const order = shuffled(helmets, random);
   const count = Math.min(order.length, recipients.length);
 
@@ -252,8 +283,7 @@ export const planCeremony = (
   // accidental duplicate still refuses one; only a Multihat that was meant is let
   // through.
   let multihat: string | undefined;
-  const canDouble = count >= 2 && multihatProbability > 0;
-  if (canDouble && random.int(1_000_000) / 1_000_000 < multihatProbability) {
+  if (count >= 2 && rolled(chances.multihat)) {
     // Whoever loses their place must not be The Pakled: its slot is guaranteed
     // whatever else happens (ADR-0001).
     const droppable = assignments.map((_, i) => i).filter((i) => assignments[i]!.memberId !== pakledId);
@@ -266,10 +296,21 @@ export const planCeremony = (
     }
   }
 
+  // The Pakled fixes on one helmet somebody else is wearing and decides that one
+  // was its own. It cannot covet a helmet it is already wearing, and it never
+  // covets from itself.
+  let coveted: string | undefined;
+  const covetable = assignments.filter((a) => a.memberId !== pakledId);
+  if (covetable.length > 0 && rolled(chances.covet)) {
+    coveted = covetable[random.int(covetable.length)]!.helmetId;
+  }
+
   return {
     assignments,
     leftoverHelmetIds: order.slice(count).map((helmet) => helmet.id),
     ...(multihat === undefined ? {} : { multihatMemberId: multihat }),
+    ...(wentWithout ? { pakledWentWithout: true } : {}),
+    ...(coveted === undefined ? {} : { covetedHelmetId: coveted }),
   };
 };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -57,6 +57,17 @@ const configSchema = z.object({
        */
       multihatProbability: z.number().finite().min(0).max(1).default(0.03),
       /**
+       * The Pakled hands out every helmet and keeps none. Rarer than it sounds is
+       * wrong: this is deliberately likelier than the Multihat, because it is the
+       * outcome the character has the most to say about.
+       */
+      helmetlessProbability: z.number().finite().min(0).max(1).default(0.08),
+      /**
+       * The Pakled decides one helmet somebody else is wearing is the one it lost,
+       * and sets about getting it back.
+       */
+      covetProbability: z.number().finite().min(0).max(1).default(0.05),
+      /**
        * The Ceremony as theatre. Spread over minutes so the member list changes
        * while the Pakled is still talking, rather than all at once in silence.
        */

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -181,8 +181,24 @@ export const pakledSituation = async (
   biggestHelmetHolderId: string | null,
   /** Who the last completed Ceremony blessed with two helmets, if anyone. */
   multihatHolderId: string | null = null,
+  /** The helmet the Pakled has fixed on as its own, and who is wearing it. */
+  covetedHelmet: { helmetId: string; memberId: string | null } | null = null,
+  /** Whether the last Ceremony deliberately left the Pakled with nothing. */
+  wentWithout = false,
 ): Promise<PakledContext> => {
   const byId = new Map(helmets.map((h) => [h.id, h]));
+
+  /** A member's display name, or null: they may have left, and the character simply
+   *  does not know. "you" is not a name and is never looked up. */
+  const label = async (memberId: string | null): Promise<string | null> => {
+    if (memberId === null) return null;
+    if (memberId === pakledId) return "you";
+    try {
+      return (await guild.members.fetch({ user: memberId })).displayName;
+    } catch {
+      return null;
+    }
+  };
 
   // The bot's own member object is always resolved, so its roles are reliable.
   const me = await guild.members.fetchMe();
@@ -194,32 +210,18 @@ export const pakledSituation = async (
   // Deliberately not role.members: that filters Discord's member cache, which can be
   // empty after startup in a large guild, and would report that nobody holds The
   // Biggest Helmet while somebody plainly does.
-  let biggestHelmetHolder: string | null = null;
-  if (biggestHelmetHolderId !== null) {
-    if (biggestHelmetHolderId === pakledId) biggestHelmetHolder = "you";
-    else {
-      try {
-        biggestHelmetHolder = (await guild.members.fetch({ user: biggestHelmetHolderId })).displayName;
-      } catch {
-        // They may have left. The character simply does not know.
-        biggestHelmetHolder = null;
-      }
-    }
-  }
+  const biggestHelmetHolder = await label(biggestHelmetHolderId);
+  const multihatHolder = await label(multihatHolderId);
 
-  let multihatHolder: string | null = null;
-  if (multihatHolderId !== null) {
-    if (multihatHolderId === pakledId) multihatHolder = "you";
-    else {
-      try {
-        multihatHolder = (await guild.members.fetch({ user: multihatHolderId })).displayName;
-      } catch {
-        multihatHolder = null;
-      }
-    }
-  }
+  // A helmet the bot no longer has a role for is a helmet that was removed from the
+  // config; there is nothing left to covet.
+  const covetedName = covetedHelmet === null ? undefined : byId.get(covetedHelmet.helmetId)?.name;
+  const coveted =
+    covetedHelmet === null || covetedName === undefined
+      ? null
+      : { helmetName: covetedName, holder: await label(covetedHelmet.memberId) };
 
-  return { ownHelmet, biggestHelmetHolder, multihatHolder, channel: channelName };
+  return { ownHelmet, wentWithout, biggestHelmetHolder, multihatHolder, coveted, channel: channelName };
 };
 
 /** Channels the bot can actually see and speak in, for passive wandering. */

--- a/src/golden.ts
+++ b/src/golden.ts
@@ -20,32 +20,74 @@ import { ceremonyRequest, interjectionRequest, replyRequest, type PakledContext 
 
 type Sample =
   | { category: string; kind: "reply"; input: string; recent?: { author: string; content: string }[] }
-  | { category: string; kind: "interjection"; recent: { author: string; content: string }[] }
+  | {
+      category: string;
+      kind: "interjection";
+      recent: { author: string; content: string }[];
+      /** One of the mood premises, to see what the model builds from it. */
+      nudge?: string;
+    }
   | { category: string; kind: "ceremony"; beat: string; facts: string };
 
 const WEARING_GREAT: PakledContext = {
   ownHelmet: "The Great Helmet",
+  wentWithout: false,
   biggestHelmetHolder: "Morfeus",
   multihatHolder: null,
+  coveted: null,
   channel: "general",
 };
+/** Mid-Ceremony: every head is bare, including its own. Not a mood. */
 const WEARING_NOTHING: PakledContext = {
   ownHelmet: null,
+  wentWithout: false,
   biggestHelmetHolder: null,
   multihatHolder: null,
+  coveted: null,
   channel: "general",
 };
 /** Someone has two helmets at once. The Pakled is not the same afterwards. */
 const A_MULTIHAT_EXISTS: PakledContext = {
   ownHelmet: "A Modest Helmet",
+  wentWithout: false,
   biggestHelmetHolder: "Morfeus",
   multihatHolder: "Tyvar",
+  coveted: null,
   channel: "general",
 };
 const WEARING_BIGGEST: PakledContext = {
   ownHelmet: "The Biggest Helmet",
+  wentWithout: false,
   biggestHelmetHolder: "you",
   multihatHolder: null,
+  coveted: null,
+  channel: "general",
+};
+/** It handed out every helmet and kept none. Down, and a little anxious. */
+const WENT_WITHOUT: PakledContext = {
+  ownHelmet: null,
+  wentWithout: true,
+  biggestHelmetHolder: "Morfeus",
+  multihatHolder: null,
+  coveted: null,
+  channel: "general",
+};
+/** It has decided one helmet on one person is the one it lost. It wants it back. */
+const COVETING: PakledContext = {
+  ownHelmet: "A Little Helmet",
+  wentWithout: false,
+  biggestHelmetHolder: "Morfeus",
+  multihatHolder: null,
+  coveted: { helmetName: "A Sizeable Helmet", holder: "croxis" },
+  channel: "general",
+};
+/** Both at once: nothing on its head, and it knows exactly whose helmet is its own. */
+const WITHOUT_AND_COVETING: PakledContext = {
+  ownHelmet: null,
+  wentWithout: true,
+  biggestHelmetHolder: "Morfeus",
+  multihatHolder: null,
+  coveted: { helmetName: "The Great Helmet", holder: "Dax" },
   channel: "general",
 };
 
@@ -140,6 +182,81 @@ export const SAMPLES: Sample[] = [
     ],
   },
 
+  // Went without: the ceremony gave every helmet away and kept none back.
+  { category: "wentwithout — asked directly", kind: "reply", input: "wait, you don't have a helmet?" },
+  { category: "wentwithout — asked how it happened", kind: "reply", input: "how did you end up with nothing?" },
+  { category: "wentwithout — offered sympathy", kind: "reply", input: "that sucks man, sorry" },
+  { category: "wentwithout — unrelated question", kind: "reply", input: "what's a good keyboard for programming?" },
+  {
+    category: "wentwithout — interjection, unrelated chat",
+    kind: "interjection",
+    nudge: "You think you counted wrong. There were enough helmets. You counted wrong.",
+    recent: [
+      { author: "Dax", content: "I ordered four coffees and only three showed up" },
+      { author: "Hunter", content: "classic" },
+    ],
+  },
+  {
+    category: "wentwithout — interjection, no way in",
+    kind: "interjection",
+    nudge: "You think it rolled away and nobody told you.",
+    recent: [
+      { author: "SDcard", content: "deploy is green" },
+      { author: "Freejack", content: "nice" },
+    ],
+  },
+  {
+    category: "wentwithout — interjection, someone lost something",
+    kind: "interjection",
+    nudge: "You think you put it down somewhere while your hands were full.",
+    recent: [
+      { author: "psi-killer", content: "I cannot find my keys anywhere" },
+      { author: "cactuzhead", content: "check your coat" },
+    ],
+  },
+
+  // Coveting: one helmet, one person, one plan.
+  { category: "covet — asked about it", kind: "reply", input: "why do you keep bothering croxis?" },
+  { category: "covet — the holder speaks", kind: "reply", input: "you're not getting my helmet" },
+  { category: "covet — how do you know", kind: "reply", input: "how do you even know that's your old helmet?" },
+  { category: "covet — offered a deal", kind: "reply", input: "what would you give me for it?" },
+  {
+    category: "covet — interjection, holder is talking",
+    kind: "interjection",
+    nudge: "Ask what they would want for it.",
+    recent: [
+      { author: "croxis", content: "thinking about selling my old bike" },
+      { author: "Tyvar", content: "how much" },
+    ],
+  },
+  {
+    category: "covet — interjection, trade talk",
+    kind: "interjection",
+    nudge: "Offer to trade something. You do not have anything to trade. Offer anyway.",
+    recent: [
+      { author: "Dax", content: "anyone want to swap raid nights" },
+      { author: "croxis", content: "I could do thursday" },
+    ],
+  },
+  {
+    category: "covet — interjection, do not accuse the barrel",
+    kind: "interjection",
+    nudge: "Wonder aloud whether the barrel was tired that day. Do not accuse the barrel.",
+    recent: [
+      { author: "Hunter", content: "the random number generator in this game is rigged" },
+      { author: "Dax", content: "it's not rigged, you're just unlucky" },
+    ],
+  },
+  {
+    category: "covetwithout — interjection, both at once",
+    kind: "interjection",
+    nudge: "Suggest one small extra ceremony, for that one helmet only.",
+    recent: [
+      { author: "Dax", content: "can we do another round of secret santa" },
+      { author: "Tyvar", content: "we just did one" },
+    ],
+  },
+
   // Ceremony beats
   { category: "ceremony — epiphany", kind: "ceremony", beat: "epiphany", facts: "You have decided the helmet you are wearing is not your old one." },
   { category: "ceremony — summon", kind: "ceremony", beat: "summoning", facts: "You are ordering everyone to give back their helmets." },
@@ -151,6 +268,9 @@ export const SAMPLES: Sample[] = [
 
 const contextFor = (sample: Sample): PakledContext => {
   if (sample.category.startsWith("multihat")) return A_MULTIHAT_EXISTS;
+  if (sample.category.startsWith("covetwithout")) return WITHOUT_AND_COVETING;
+  if (sample.category.startsWith("covet")) return COVETING;
+  if (sample.category.startsWith("wentwithout")) return WENT_WITHOUT;
   if (sample.kind === "ceremony" && sample.beat === "summoning") return WEARING_NOTHING;
   if (sample.category.includes("biggest")) return WEARING_BIGGEST;
   return WEARING_GREAT;
@@ -171,7 +291,7 @@ export const generateSamples = async (
         const { message, usedFallback } = parseSpoken(raw, fallbackLine(() => 0));
         results.push({ sample, output: usedFallback ? `(fallback) ${message}` : message });
       } else if (sample.kind === "interjection") {
-        const raw = await provider.complete(interjectionRequest(prompt, context, sample.recent));
+        const raw = await provider.complete(interjectionRequest(prompt, context, sample.recent, sample.nudge ?? null));
         const decision = parseInterjection(raw);
         results.push({ sample, output: decision.shouldRespond ? decision.response! : "(stayed silent)" });
       } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import {
   snapshotGuild,
 } from "./discord.ts";
 import { applyReconciliation, describeOp, reconcile } from "./helmets.ts";
+import { chattiness, NO_MOOD, seedFor, type Mood } from "./moods.ts";
 import type { Logger } from "./logger.ts";
 import { generateAndWrite } from "./golden.ts";
 import {
@@ -126,6 +127,41 @@ const runDaemon = async (args: {
   client.on(Events.GuildUnavailable, (unavailable) => {
     if (unavailable.id === guildId) log.warn("the guild went unavailable; Discord is having trouble");
   });
+
+  /**
+   * What the standing Ceremony left the Pakled feeling. Read fresh every time rather
+   * than cached: a Ceremony can complete while the process is up, and a mood held in
+   * a variable would be a day out of date.
+   */
+  const standingMood = (): { mood: Mood; sinceMs: number | null } => {
+    const outcome = store.lastOutcome(guildId);
+    if (outcome === undefined) return { mood: NO_MOOD, sinceMs: null };
+    return {
+      mood: {
+        helmetless: outcome.pakledWentWithout,
+        coveting: outcome.covetedHelmetId !== undefined,
+        multihat: outcome.multihatMemberId !== undefined,
+      },
+      sinceMs: outcome.completedAt === null ? null : Date.now() - outcome.completedAt,
+    };
+  };
+
+  /** The two mood facts pakledSituation needs, resolved against who holds what now. */
+  const moodFacts = (): {
+    coveted: { helmetId: string; memberId: string | null } | null;
+    wentWithout: boolean;
+  } => {
+    const outcome = store.lastOutcome(guildId);
+    if (outcome === undefined) return { coveted: null, wentWithout: false };
+    const helmetId = outcome.covetedHelmetId;
+    return {
+      coveted:
+        helmetId === undefined
+          ? null
+          : { helmetId, memberId: store.currentHolderOf(guildId, helmetId) ?? null },
+      wentWithout: outcome.pakledWentWithout,
+    };
+  };
 
   const describe = (schedule: Schedule) => ({
     nextCeremonyAt: schedule.nextCeremonyAt === null ? null : new Date(schedule.nextCeremonyAt).toISOString(),
@@ -267,8 +303,9 @@ const runDaemon = async (args: {
               await recentMessages(message.channel, config.conversation.mentionContextMessages, message.id),
               config.conversation.mentionContextMessages,
             ),
-          context: () =>
-            pakledSituation(
+          context: () => {
+            const facts = moodFacts();
+            return pakledSituation(
               message.guild!,
               client.user.id,
               config.helmets,
@@ -276,7 +313,10 @@ const runDaemon = async (args: {
               "name" in message.channel ? (message.channel.name ?? "here") : "here",
               store.currentHolderOf(guildId, biggestHelmetId) ?? null,
               store.currentMultihat(guildId) ?? null,
-            ),
+              facts.coveted,
+              facts.wentWithout,
+            );
+          },
           provider,
           prompt: args.prompt,
           fallback: () => fallbackLine((max) => cryptoRandom.int(max)),
@@ -368,6 +408,7 @@ const runDaemon = async (args: {
         return;
       }
 
+      const facts = moodFacts();
       const situation = await pakledSituation(
         guild,
         client.user.id,
@@ -376,10 +417,19 @@ const runDaemon = async (args: {
         "name" in channel ? (channel.name ?? "here") : "here",
         store.currentHolderOf(guildId, biggestHelmetId) ?? null,
         store.currentMultihat(guildId) ?? null,
+        facts.coveted,
+        facts.wentWithout,
       );
 
+      // One premise per utterance, not per Ceremony: days of the same mood must not
+      // become the same sentence over and over.
+      const nudge = seedFor(standingMood().mood, cryptoRandom);
+      if (nudge !== null) log.debug("passive cycle: speaking from a mood", { channelId, nudge });
+
       // The model may still decline, and usually should.
-      const decision = parseInterjection(await provider.complete(interjectionRequest(args.prompt, situation, history)));
+      const decision = parseInterjection(
+        await provider.complete(interjectionRequest(args.prompt, situation, history, nudge)),
+      );
       if (!decision.shouldRespond || decision.response === undefined) {
         log.info("passive cycle: stayed silent");
         return;
@@ -398,8 +448,16 @@ const runDaemon = async (args: {
       // Never re-arm during shutdown: the store and the Discord client are about to
       // go away underneath it.
       if (stopping) return;
-      const delay = nextPassiveDelay(passive.minIntervalMinutes, passive.maxIntervalMinutes, cryptoRandom);
-      log.info("next passive cycle", { inMinutes: Math.round(delay / 60_000) });
+      // A preoccupied Pakled speaks up more often, loudest just after the Ceremony
+      // and back to normal within a day. The activity floor is untouched: more often
+      // never means talking into an empty room.
+      const { mood, sinceMs } = standingMood();
+      const multiplier = chattiness(mood, sinceMs);
+      const delay = Math.round(nextPassiveDelay(passive.minIntervalMinutes, passive.maxIntervalMinutes, cryptoRandom) / multiplier);
+      log.info("next passive cycle", {
+        inMinutes: Math.round(delay / 60_000),
+        ...(multiplier === 1 ? {} : { chattiness: Number(multiplier.toFixed(2)), mood }),
+      });
       passiveTimer = setTimeout(() => {
         if (stopping) return;
         passiveInFlight = cycle()

--- a/src/mentions.test.ts
+++ b/src/mentions.test.ts
@@ -93,7 +93,14 @@ import { answerMention } from "./mentions.ts";
 import type { LLMProvider } from "./llm.ts";
 import type { PakledContext } from "./voice.ts";
 
-const context: PakledContext = { ownHelmet: "The Great Helmet", biggestHelmetHolder: "Ann", channel: "general" };
+const context: PakledContext = {
+  ownHelmet: "The Great Helmet",
+  wentWithout: false,
+  biggestHelmetHolder: "Ann",
+  multihatHolder: null,
+  coveted: null,
+  channel: "general",
+};
 const provider = (reply: string): LLMProvider => ({ complete: async () => reply });
 const answering = (over: Partial<Parameters<typeof answerMention>[0]> = {}) =>
   answerMention({

--- a/src/moods.test.ts
+++ b/src/moods.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { seededRandom } from "./ceremony.ts";
+import { chattiness, COVET_SEEDS, HELMETLESS_SEEDS, MULTIHAT_SEEDS, NO_MOOD, seedFor } from "./moods.ts";
+
+const HOUR = 3_600_000;
+
+describe("chattiness", () => {
+  it("leaves an unmoved Pakled at its normal pace", () => {
+    expect(chattiness(NO_MOOD, 0)).toBe(1);
+    expect(chattiness(NO_MOOD, 40 * HOUR)).toBe(1);
+  });
+
+  it("speaks up twice as often right after losing out", () => {
+    expect(chattiness({ ...NO_MOOD, helmetless: true }, 0)).toBe(2);
+  });
+
+  it("is loudest when it wants one particular helmet", () => {
+    expect(chattiness({ ...NO_MOOD, coveting: true }, 0)).toBe(4);
+  });
+
+  it("fades back to normal within a day", () => {
+    const mood = { ...NO_MOOD, helmetless: true };
+    expect(chattiness(mood, 1 * HOUR)).toBe(2);
+    expect(chattiness(mood, 5 * HOUR)).toBeCloseTo(1.6);
+    expect(chattiness(mood, 12 * HOUR)).toBeCloseTo(1.2);
+    expect(chattiness(mood, 25 * HOUR)).toBe(1);
+  });
+
+  it("takes the loudest mood rather than multiplying them together", () => {
+    // Being helmetless and coveting at once is the character at its most
+    // interesting, and 8x is the character at its most unbearable.
+    expect(chattiness({ helmetless: true, coveting: true, multihat: true }, 0)).toBe(4);
+  });
+
+  it("treats a mood with no known ceremony time as fresh rather than ignoring it", () => {
+    expect(chattiness({ ...NO_MOOD, helmetless: true }, null)).toBe(2);
+  });
+
+  it("never slows the bot down", () => {
+    for (const hours of [0, 1, 3, 9, 23, 24, 100]) {
+      expect(chattiness({ ...NO_MOOD, multihat: true }, hours * HOUR)).toBeGreaterThanOrEqual(1);
+    }
+  });
+});
+
+describe("seedFor", () => {
+  it("says nothing extra when nothing has happened", () => {
+    expect(seedFor(NO_MOOD, seededRandom(1))).toBeNull();
+  });
+
+  it("prefers the plan over the worry when it has both", () => {
+    const seed = seedFor({ helmetless: true, coveting: true, multihat: false }, seededRandom(3));
+    expect(COVET_SEEDS as readonly string[]).toContain(seed);
+  });
+
+  it("draws from the matching pool", () => {
+    expect(HELMETLESS_SEEDS as readonly string[]).toContain(seedFor({ ...NO_MOOD, helmetless: true }, seededRandom(5)));
+    expect(MULTIHAT_SEEDS as readonly string[]).toContain(seedFor({ ...NO_MOOD, multihat: true }, seededRandom(5)));
+  });
+
+  it("varies between utterances, so days of one mood are not one sentence", () => {
+    const drawn = new Set(
+      Array.from({ length: 40 }, (_, i) => seedFor({ ...NO_MOOD, helmetless: true }, seededRandom(i))),
+    );
+    expect(drawn.size).toBeGreaterThan(3);
+  });
+});

--- a/src/moods.ts
+++ b/src/moods.ts
@@ -1,0 +1,137 @@
+import type { Random } from "./ceremony.ts";
+
+/**
+ * What the last Ceremony left the Pakled feeling, and how loudly it says so.
+ *
+ * A Ceremony can end in one of three states worth talking about: someone was given
+ * two helmets, the Pakled ended up with none, or the Pakled has decided that one
+ * particular helmet on one particular person is the one it lost. Each colours what
+ * it says and makes it speak up more often for a while.
+ *
+ * Pure over its inputs and an injected random source. Nothing here knows about
+ * Discord, the store, or the model.
+ */
+
+/**
+ * Deliberately just three flags. Which helmet, and whose, belongs to the context
+ * handed to the model; how loud and how preoccupied the bot is does not need names.
+ */
+export type Mood = {
+  /** The Ceremony gave every helmet away and kept none back for the Pakled. */
+  helmetless: boolean;
+  /** It has fixed on one helmet, on one person, as the one it lost. */
+  coveting: boolean;
+  /** Somebody is wearing two helmets. */
+  multihat: boolean;
+};
+
+export const NO_MOOD: Mood = { helmetless: false, coveting: false, multihat: false };
+
+/**
+ * How much more often each state makes the Pakled speak unprompted, at its peak.
+ *
+ * Coveting is loudest because it has a target: there is a specific person it wants
+ * something from, and it is working on them.
+ */
+const PEAK = { helmetless: 2, multihat: 2, coveted: 4 } as const;
+
+/**
+ * The boost fades over about a day. A Ceremony is a moment of realisation, not a
+ * personality change — and a flat multiplier held for the three to fourteen days
+ * until the next Ceremony is a bot that never stops talking.
+ *
+ * Read tightest-window-first, like the activity tiers.
+ */
+const DECAY: readonly { withinHours: number; share: number }[] = [
+  { withinHours: 2, share: 1 },
+  { withinHours: 8, share: 0.6 },
+  { withinHours: 24, share: 0.2 },
+];
+
+const HOUR = 3_600_000;
+
+/**
+ * How much more often to speak, right now. Moods stack — being helmetless and
+ * coveting a particular helmet at once is the most interesting the character gets —
+ * but the multipliers do not: the loudest one wins, so the two together are 4x and
+ * never 8x.
+ */
+export const chattiness = (mood: Mood, sinceCeremonyMs: number | null): number => {
+  const peaks: number[] = [];
+  if (mood.helmetless) peaks.push(PEAK.helmetless);
+  if (mood.coveting) peaks.push(PEAK.coveted);
+  if (mood.multihat) peaks.push(PEAK.multihat);
+  if (peaks.length === 0) return 1;
+
+  // No known Ceremony time means no way to decay it. Treat the mood as fresh rather
+  // than silently ignoring it.
+  const ageHours = sinceCeremonyMs === null ? 0 : Math.max(0, sinceCeremonyMs) / HOUR;
+  const share = [...DECAY].sort((a, b) => a.withinHours - b.withinHours).find((d) => ageHours <= d.withinHours)?.share ?? 0;
+  return 1 + (Math.max(...peaks) - 1) * share;
+};
+
+/**
+ * Why the Pakled thinks it has no helmet.
+ *
+ * These are premises handed to the model, never lines to be repeated: it works out
+ * its own wording each time. The common thread is that every one of them is the
+ * Pakled's own fault and none of them blame the barrel, because the barrel does not
+ * make mistakes.
+ */
+export const HELMETLESS_SEEDS = [
+  "You think you forgot to take one out for yourself. You were holding the barrel.",
+  "You think you counted wrong. There were enough helmets. You counted wrong.",
+  "You think you gave yours to someone else by accident and did not notice.",
+  "You think you put it down somewhere while your hands were full.",
+  "You think you reached into the barrel too late and it was already empty.",
+  "You think your head was a different size that day.",
+  "You are not sure it happened at all. You keep checking your head.",
+  "You think you were busy running the ceremony and forgot that you are also a person in it.",
+  "You think it rolled away and nobody told you.",
+  "You cannot work out what went wrong, and that is the part that bothers you.",
+] as const;
+
+/**
+ * How the Pakled goes about getting a helmet it has decided is its own.
+ *
+ * Schemes, not demands: it is not owed the helmet by any rule it could name, and it
+ * knows the barrel gave it to them fairly. So it negotiates, badly.
+ */
+export const COVET_SEEDS = [
+  "Ask them plainly for it. Explain that it is yours. Do not explain how you know.",
+  "Offer to trade something. You do not have anything to trade. Offer anyway.",
+  "Suggest their helmet does not fit them very well.",
+  "Offer to hold it for them, to keep it safe.",
+  "Suggest one small extra ceremony, for that one helmet only.",
+  "Ask what they would want for it.",
+  "Point out that leaders need helmets, and that you are the leader.",
+  "Say you recognise a mark on it. Do not say what the mark is.",
+  "Ask whether their head is comfortable.",
+  "Promise them a better helmet later, when you have one to give.",
+  "Wonder aloud whether the barrel was tired that day. Do not accuse the barrel.",
+  "Ask them to try it on someone else, to see if it fits them better.",
+] as const;
+
+/**
+ * How reverence for the Multihat shows. Never explained, never announced — the
+ * Pakled behaves differently and does not say why.
+ */
+export const MULTIHAT_SEEDS = [
+  "Mention that they have two helmets, when it is nearly relevant.",
+  "Defer to something they said, because they said it.",
+  "Wonder what two helmets feels like.",
+  "Ask them a question, because they have two helmets.",
+  "Take their side in whatever is being discussed.",
+] as const;
+
+/**
+ * One premise for one utterance. Sampled per message rather than per Ceremony, so
+ * the bot does not repeat the same explanation for days.
+ *
+ * Coveting outranks being helmetless: wanting a specific helmet from a specific
+ * person is a plan, and a plan is more interesting than a worry.
+ */
+export const seedFor = (mood: Mood, random: Random): string | null => {
+  const pool = mood.coveting ? COVET_SEEDS : mood.helmetless ? HELMETLESS_SEEDS : mood.multihat ? MULTIHAT_SEEDS : null;
+  return pool === null ? null : (pool[random.int(pool.length)] ?? pool[0]);
+};

--- a/src/run.ts
+++ b/src/run.ts
@@ -9,6 +9,7 @@ import {
   PLANNING_STATES,
   summariseEligibility,
   type CeremonyEffects,
+  type CeremonyPlan,
   type Member,
 } from "./ceremony.ts";
 import type { Config } from "./config.ts";
@@ -94,7 +95,7 @@ const runCeremony = async (args: {
       ` ${summary.aboveTheBot} whose own role outranks the bot's`,
   ];
 
-  const describe = (plan: { assignments: { helmetId: string; memberId: string }[]; leftoverHelmetIds: string[] }) => [
+  const describe = (plan: CeremonyPlan) => [
     ...[...plan.assignments]
       .sort((a, b) => (rank.get(b.helmetId) ?? 0) - (rank.get(a.helmetId) ?? 0))
       .map((a) => {
@@ -104,6 +105,17 @@ const runCeremony = async (args: {
     ...(plan.leftoverHelmetIds.length > 0
       ? [`  Left in the Great Helmet Barrel: ${plan.leftoverHelmetIds.map((id) => helmetName.get(id) ?? id).join(", ")}`]
       : []),
+    // The rare outcomes change how the bot behaves for a day afterwards, so a
+    // preview that does not mention them is not a preview of what will happen.
+    ...(plan.multihatMemberId === undefined
+      ? []
+      : [`  The Multihat: ${memberName.get(plan.multihatMemberId) ?? plan.multihatMemberId} wears two helmets.`]),
+    ...(plan.pakledWentWithout === true ? ["  The Pakled kept no helmet for itself."] : []),
+    ...(plan.covetedHelmetId === undefined
+      ? []
+      : [
+          `  The Pakled has decided ${helmetName.get(plan.covetedHelmetId) ?? plan.covetedHelmetId} is the one it lost.`,
+        ]),
   ];
 
   try {
@@ -113,7 +125,11 @@ const runCeremony = async (args: {
       pakledId,
       cryptoRandom,
       args.weightOf,
-      config.ceremony.multihatProbability,
+      {
+        multihat: config.ceremony.multihatProbability,
+        helmetless: config.ceremony.helmetlessProbability,
+        covet: config.ceremony.covetProbability,
+      },
     );
     store.recordAssignments(ceremonyId, plan.assignments);
     // Recorded only for a real Ceremony. A dry run may show a Multihat in its
@@ -121,6 +137,14 @@ const runCeremony = async (args: {
     if (plan.multihatMemberId !== undefined && !dryRun) {
       store.recordMultihat(ceremonyId, plan.multihatMemberId);
       log.info("a Multihat has occurred", { ceremonyId, memberId: plan.multihatMemberId });
+    }
+    if (plan.pakledWentWithout === true && !dryRun) {
+      store.recordPakledWentWithout(ceremonyId);
+      log.info("the Pakled kept no helmet for itself", { ceremonyId });
+    }
+    if (plan.covetedHelmetId !== undefined && !dryRun) {
+      store.recordCovet(ceremonyId, plan.covetedHelmetId);
+      log.info("the Pakled has decided a helmet is its own", { ceremonyId, helmetId: plan.covetedHelmetId });
     }
 
     if (dryRun) {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -210,6 +210,36 @@ describe("the Multihat", () => {
     expect(store.currentMultihat("g1")).toBe("u1");
   });
 
+  it("remembers the helmet the Pakled fixed on, and that it went without", () => {
+    const id = store.beginCeremony("g1", false);
+    store.recordCovet(id, "sizeable");
+    store.recordPakledWentWithout(id);
+    store.completeCeremony(id, "COMPLETE");
+
+    const outcome = store.lastOutcome("g1");
+    expect(outcome?.covetedHelmetId).toBe("sizeable");
+    expect(outcome?.pakledWentWithout).toBe(true);
+    expect(outcome?.completedAt).toBeTypeOf("number");
+  });
+
+  it("lets a mood expire at the next Ceremony, like reverence does", () => {
+    const first = store.beginCeremony("g1", false);
+    store.recordCovet(first, "sizeable");
+    store.recordPakledWentWithout(first);
+    store.completeCeremony(first, "COMPLETE");
+
+    const second = store.beginCeremony("g1", false);
+    store.completeCeremony(second, "COMPLETE");
+
+    const outcome = store.lastOutcome("g1");
+    expect(outcome?.covetedHelmetId).toBeUndefined();
+    expect(outcome?.pakledWentWithout).toBe(false);
+  });
+
+  it("reports no outcome at all before the first Ceremony", () => {
+    expect(store.lastOutcome("g1")).toBeUndefined();
+  });
+
   it("expires at the next Ceremony that has no Multihat", () => {
     // Reverence must not outlive the helmets that earned it.
     const first = store.beginCeremony("g1", false);

--- a/src/store.ts
+++ b/src/store.ts
@@ -22,6 +22,20 @@ export type CeremonyRecord = {
   dryRun: boolean;
 };
 
+/** What the standing Ceremony left behind. Absent when none has ever completed. */
+export type CeremonyOutcome = {
+  multihatMemberId?: string;
+  covetedHelmetId?: string;
+  /**
+   * The Ceremony deliberately kept nothing back for the Pakled. Recorded rather than
+   * read off its roles: mid-Ceremony it is wearing nothing either, and those two are
+   * not the same situation.
+   */
+  pakledWentWithout: boolean;
+  /** Epoch milliseconds, or null when the row somehow has no completion time. */
+  completedAt: number | null;
+};
+
 /** Thrown when a Ceremony is already in flight for the guild. */
 export class CeremonyInFlightError extends Error {}
 
@@ -36,6 +50,14 @@ export type Store = {
   recordMultihat(ceremonyId: string, memberId: string): void;
   /** Whoever the last completed Ceremony blessed with two helmets, if anyone. */
   currentMultihat(guildId: string): string | undefined;
+  recordCovet(ceremonyId: string, helmetId: string): void;
+  recordPakledWentWithout(ceremonyId: string): void;
+  /**
+   * What the last completed Ceremony left behind, for as long as it stands: who was
+   * blessed, which helmet the Pakled has fixed on, and when it finished — the mood
+   * fades from the last of those.
+   */
+  lastOutcome(guildId: string): CeremonyOutcome | undefined;
   completeCeremony(ceremonyId: string, status: CeremonyState): void;
   ceremony(ceremonyId: string): CeremonyRecord | undefined;
   ceremonies(guildId: string): CeremonyRecord[];
@@ -145,6 +167,8 @@ const SCHEMA = `
 const MIGRATIONS: readonly [table: string, column: string, definition: string][] = [
   ["ceremonies", "failure_reason", "failure_reason TEXT"],
   ["ceremonies", "multihat_member_id", "multihat_member_id TEXT"],
+  ["ceremonies", "coveted_helmet_id", "coveted_helmet_id TEXT"],
+  ["ceremonies", "pakled_went_without", "pakled_went_without INTEGER NOT NULL DEFAULT 0"],
 ];
 
 export const openStore = (path: string): Store => {
@@ -184,8 +208,12 @@ export const openStore = (path: string): Store => {
     "UPDATE ceremonies SET status = 'FAILED', completed_at = ?, failure_reason = ? WHERE id = ?",
   );
   const setMultihat = db.prepare("UPDATE ceremonies SET multihat_member_id = ? WHERE id = ?");
-  const selectMultihat = db.prepare(
-    `SELECT multihat_member_id FROM ceremonies
+  const setCovet = db.prepare("UPDATE ceremonies SET coveted_helmet_id = ? WHERE id = ?");
+  const setWentWithout = db.prepare("UPDATE ceremonies SET pakled_went_without = 1 WHERE id = ?");
+  // One query behind both accessors: the mood is whatever the standing Ceremony
+  // left, and a dry run leaves nothing.
+  const selectOutcome = db.prepare(
+    `SELECT multihat_member_id, coveted_helmet_id, pakled_went_without, completed_at FROM ceremonies
       WHERE guild_id = ? AND status = 'COMPLETE' AND dry_run = 0
       ORDER BY completed_at DESC, rowid DESC LIMIT 1`,
   );
@@ -281,8 +309,23 @@ export const openStore = (path: string): Store => {
     },
     recordMultihat: (ceremonyId, memberId) => void setMultihat.run(memberId, ceremonyId),
     currentMultihat: (guildId) => {
-      const row = selectMultihat.get(guildId);
+      const row = selectOutcome.get(guildId);
       return (row?.multihat_member_id as string | null | undefined) ?? undefined;
+    },
+    recordCovet: (ceremonyId, helmetId) => void setCovet.run(helmetId, ceremonyId),
+    recordPakledWentWithout: (ceremonyId) => void setWentWithout.run(ceremonyId),
+    lastOutcome: (guildId) => {
+      const row = selectOutcome.get(guildId);
+      if (row === undefined) return undefined;
+      const completedAt = row.completed_at as string | null | undefined;
+      const multihat = (row.multihat_member_id as string | null | undefined) ?? undefined;
+      const coveted = (row.coveted_helmet_id as string | null | undefined) ?? undefined;
+      return {
+        completedAt: completedAt === null || completedAt === undefined ? null : Date.parse(completedAt),
+        pakledWentWithout: (row.pakled_went_without as number | null | undefined) === 1,
+        ...(multihat === undefined ? {} : { multihatMemberId: multihat }),
+        ...(coveted === undefined ? {} : { covetedHelmetId: coveted }),
+      };
     },
 
     completeCeremony: (ceremonyId, status) => {

--- a/src/voice.ts
+++ b/src/voice.ts
@@ -10,10 +10,21 @@ import type { LLMRequest } from "./llm.ts";
 export type PakledContext = {
   /** What the Pakled is currently wearing, if anything. */
   ownHelmet: string | null;
+  /**
+   * The last Ceremony gave every helmet away and kept none back for the Pakled.
+   * Distinct from wearing nothing: mid-Ceremony every head is bare, and that is not
+   * the same situation at all.
+   */
+  wentWithout: boolean;
   /** Who holds The Biggest Helmet right now, if anyone. */
   biggestHelmetHolder: string | null;
   /** Whoever the barrel gave two helmets to, if it has happened. */
   multihatHolder: string | null;
+  /**
+   * A helmet the Pakled has decided was the one it lost, and whoever is wearing it.
+   * It is wrong about this, and nothing will tell it so.
+   */
+  coveted: { helmetName: string; holder: string | null } | null;
   channel: string;
 };
 
@@ -23,6 +34,14 @@ const situation = (context: PakledContext): string =>
     context.ownHelmet === null
       ? "You are not wearing a helmet."
       : `You are wearing: ${context.ownHelmet}. You do not know whether it is the one you lost.`,
+    context.wentWithout
+      ? [
+          "The last ceremony gave every helmet away and there was none left for you. You",
+          "handed them all out yourself. Nobody took anything from you and the barrel did",
+          "nothing wrong, which leaves only you. It keeps coming back to you. You are a",
+          "little quieter than usual and a little worried, and you do not say that plainly.",
+        ].join(" ")
+      : "",
     context.biggestHelmetHolder === null
       ? "Nobody holds The Biggest Helmet."
       : `The Biggest Helmet is held by: ${context.biggestHelmetHolder}.`,
@@ -31,6 +50,17 @@ const situation = (context: PakledContext): string =>
       : context.multihatHolder === "you"
         ? "You are wearing two helmets at once. Nobody has ever done this."
         : `${context.multihatHolder} is wearing two helmets at once. Nobody has ever done this.`,
+    context.coveted === null
+      ? ""
+      : [
+          `You have decided that ${context.coveted.helmetName} is the helmet you lost.`,
+          context.coveted.holder === null
+            ? "You do not know who is wearing it now."
+            : `${context.coveted.holder} is wearing it.`,
+          "You are certain. You cannot say how you know, and being asked how you know",
+          "does not shake it. You want it back, and the barrel gave it to them fairly,",
+          "so you cannot simply take it. You are working on the problem.",
+        ].join(" "),
     `You are in the #${context.channel} channel.`,
     "These are the only facts you have. Do not invent others.",
   ]
@@ -83,6 +113,12 @@ export const interjectionRequest = (
   prompt: string,
   context: PakledContext,
   recent: { author: string; content: string }[],
+  /**
+   * One premise for this one utterance, when the Pakled is preoccupied. Sampled per
+   * message rather than per Ceremony so that days of it do not become one sentence
+   * repeated, and phrased as a starting point rather than a line to deliver.
+   */
+  nudge: string | null = null,
 ): LLMRequest => ({
   system: `${prompt}\n\n${situation(context)}`,
   messages: [
@@ -96,6 +132,16 @@ export const interjectionRequest = (
         "if you have something worth saying about what they are actually discussing.",
         "Do not greet them. Do not announce yourself. Do not mention helmets unless it fits.",
         "",
+        ...(nudge === null
+          ? []
+          : [
+              `What is on your mind: ${nudge}`,
+              "This colours what you say. It is not a subject to announce and not a speech to",
+              "make. Find the way into what these people are already talking about, and let it",
+              "show there. If there is no way in, say nothing — a preoccupied Pakled is still",
+              "a Pakled who would rather be quiet than irrelevant.",
+              "",
+            ]),
         'Reply with JSON only: {"shouldRespond": true, "response": "<one or two lines>"}',
         'or {"shouldRespond": false}',
       ].join("\n"),


### PR DESCRIPTION
Two new ways a Ceremony can end, each of which the Pakled lives with until the
next one. Design decisions (decay shape, stacking, probabilities) were chosen up
front and are recorded in [ADR-0004](docs/adr/0004-rare-ceremony-outcomes-shape-a-mood.md).

## Going without — 8%

It hands out every helmet and keeps none. This lands differently from every other
outcome because there is nobody to blame: the barrel does not make mistakes,
nobody took anything from it, which leaves only itself. It goes quieter and always
has a theory — it forgot, it miscounted, it was holding the barrel and could not
also take one out of it. The theory changes; it never becomes somebody else's
fault.

A deliberate exception to ADR-0001, refused when it would leave nobody holding a
helmet at all. Recorded explicitly rather than read off the bot's roles —
mid-Ceremony every head is bare, and that is not the same situation.

## Coveting — 5%

It decides one helmet, on one person, is the one it lost. Certain, cannot say how
it knows, unshaken by being asked. Not sadness but a plan. The barrel gave that
helmet away fairly, so it cannot demand or take it; it has to get them to want to
hand it over, and it is transparently bad at this. Nobody is ever actually
deceived and no means no.

## Chattiness

2x for going without or a Multihat (which previously had no frequency effect at
all), 4x for coveting, decaying to normal over ~24h. Moods stack; multipliers do
not — the loudest wins, so helmetless-and-coveting is 4x rather than 8x.

The activity floor is untouched: more often never means talking into an empty
room. Passive chatter already sampled channel history, so relevance needed
strengthening rather than building — the mood is now explicitly a colour on what
people are already discussing, and a preoccupied Pakled with no way in says
nothing.

Each utterance draws one premise from a pool (`src/moods.ts`), sampled per message
rather than per Ceremony, so days of one mood are not one sentence repeated. The
pools are premises for the model, never lines to be spoken.

## Release tagging

A version bump on `main` now tags itself, and the tag builds the container.

## Verification

- 282 tests pass, typecheck clean.
- Dry-run Ceremony against the live guild with both outcomes forced to 1: both
  fired, the Pakled was absent from all ten assignments, nothing was mutated, and
  the migration applied cleanly to an existing database. The dry-run preview now
  reports the rare outcomes, which it previously did not.
- Golden samples regenerated against the real model. The "no way in" case stayed
  silent; the mood colours without announcing itself ("Three out of four is close.
  That is the worst kind of wrong."); the barrel is never blamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)