### PR TITLE
Write the GitHub release from the changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,3 +55,49 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # The container is the release; this is the note that says so. Kept separate from
+  # publish so a release never announces an image that failed to build.
+  announce:
+    needs: publish
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create the GitHub release from the changelog
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          version="${tag#v}"
+
+          # Re-running a tag must not fail the build, and must never overwrite notes
+          # that have since been edited by hand.
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "Release $tag already exists. Leaving it alone."
+            exit 0
+          fi
+
+          heading="## v$version"
+          title=$(awk -v h="$heading" 'index($0,h)==1 {print substr($0,4); exit}' CHANGELOG.md)
+          notes=$(awk -v h="$heading" '
+            index($0, h) == 1 { found=1; next }
+            found && index($0, "## v") == 1 { exit }
+            found { print }
+          ' CHANGELOG.md)
+
+          image="ghcr.io/${GITHUB_REPOSITORY,,}"
+          footer=$(printf '\n---\n\n```\ndocker pull %s:%s\n```\n' "$image" "$version")
+
+          # A version with no changelog section still gets a release, from whatever
+          # GitHub can work out of the commits.
+          if [ -z "$notes" ]; then
+            echo "No changelog section for v$version; falling back to generated notes."
+            gh release create "$tag" --title "${title:-$tag}" --generate-notes --notes "$footer"
+          else
+            gh release create "$tag" --title "${title:-$tag}" --notes "$notes$footer"
+          fi
+          echo "Created release $tag."


### PR DESCRIPTION
Tagging built a container but never created a GitHub release — v0.1.0 and v0.2.0
were both written by hand, and v0.3.0 had no release at all until it was
backfilled.

The changelog section for the version being tagged is already the note anyone
would write, so the tag now publishes it verbatim, titled from the section
heading (`## v0.3.0 — The Helmet You Are Sure About` → that, minus the `##`),
with a `docker pull` line appended.

Details worth knowing:

- Runs as a job **after** `publish`, so a release never announces an image that
  failed to build.
- Leaves an existing release alone rather than overwriting notes edited by hand,
  so re-running a tag is safe.
- Falls back to GitHub's generated notes if a version has no changelog section.
- Guarded on the ref being a tag, so `workflow_dispatch` on a branch cannot
  create a release named after the branch.

Verified: the YAML parses to three jobs, and the extraction was run locally
against `CHANGELOG.md` to produce the v0.3.0 release that now exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)