### PR TITLE
Publish the bare major, so every pointer moves

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,11 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            # Deliberately not type=semver,pattern={{major}}: metadata-action omits
+            # a bare major for 0.x, on the reasoning that "0" promises a stability
+            # 0.x has not earned. That reasoning is sound and this project wants the
+            # moving pointer anyway, so the major is matched out of the tag instead.
+            type=match,pattern=v(\d+),group=1
             # Keyed off the tag, not the branch: this workflow runs on a tag push,
             # where is_default_branch is false and `latest` would never be published.
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.4.2 — Every Pointer Moves
+
+A release now publishes the bare major as well, so `0` follows the newest release
+alongside `0.4` and `latest`, while every exact version keeps its own tag forever.
+
+`docker/metadata-action` omits a bare major for 0.x versions by design, on the
+reasoning that a `0` tag promises a stability a 0.x project has not earned. That is
+a fair default and the wrong one here, so the major is matched out of the git tag
+rather than derived from the semver pattern.
+
+Nothing else changed. `{{major}}.{{minor}}` was already moving correctly — `0.4`
+pointed at v0.4.1 the moment it was published.
+
 ## v0.4.1 — Still A Pakled
 
 ### A broken guild costs the bot its roles, not its voice

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-pakled-helmetbot",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
A release published `0.4.1`, `0.4` and `latest`. It never published `0`.

The cause is a deliberate `docker/metadata-action` behaviour: it omits
`{{major}}` for 0.x versions, because a bare `0` tag implies a stability promise
a 0.x project has not made. That is a good default and the wrong one here, so the
major is matched out of the git tag with `type=match` rather than derived from the
semver pattern.

After this, `v0.4.2` publishes `0.4.2`, `0.4`, `0` and `latest`, and every exact
version keeps its own tag permanently.

**Correcting something I reported on the last release:** I said `0.4` had not moved
to v0.4.1. It had. Checking digests rather than the tag list shows `0.4`, `0.4.1`
and `latest` all resolving to `sha256:cba17aec…` while `0.4.0` retains
`sha256:c31d9080…`. `{{major}}.{{minor}}` was working correctly the whole time and
only the bare major was ever missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)